### PR TITLE
ESDK-274, ESDK-280: Use the clean-after-checkout branch of esdk-jenkins-lib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,9 @@ node {
 		ansiColor('xterm') {
 			try {
 				stage('Setup') {
-					prepareEnv()
 					checkout scm
+					sh 'git clean -fdx'
+					prepareEnv()
 					shInstallDockerCompose()
 					initGradleProps()
 					showGradleProps()


### PR DESCRIPTION
Clean the workingdir after each checkout to have reproducible builds.